### PR TITLE
Fix documentation parsing and tighten static checks

### DIFF
--- a/ifacemaker.go
+++ b/ifacemaker.go
@@ -23,7 +23,7 @@ type cmdlineArgs struct {
 
 	// jessevdk/go-flags doesn't support default values for boolean flags,
 	// so we use a string for backwards-compatibility and then convert it to a bool later.
-	CopyDocs string `short:"d" long:"doc" description:"Copy docs from methods" option:"true" option:"false" default:"true"`
+	CopyDocs string `short:"d" long:"doc" description:"Copy docs from methods" choice:"true" choice:"false" default:"true"`
 	copyDocs bool
 
 	CopyTypeDoc bool   `short:"D" long:"type-doc" description:"Copy type doc from struct"`
@@ -86,6 +86,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		defer f.Close()
 		if _, err := f.Write(result); err != nil {
 			log.Fatal(err)
 		}

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -48,26 +48,15 @@ func (m *Method) Lines() []string {
 // Otherwise, it returns an empty string.
 func GetTypeDeclarationName(decl ast.Decl) string {
 	gd, ok := decl.(*ast.GenDecl)
-	if !ok {
+	if !ok || gd.Tok != token.TYPE || len(gd.Specs) == 0 {
 		return ""
 	}
 
-	if gd.Tok != token.TYPE {
-		return ""
+	if ts, ok := gd.Specs[0].(*ast.TypeSpec); ok {
+		return ts.Name.Name
 	}
 
-	typeName := ""
-	for _, spec := range gd.Specs {
-		typeSpec, ok := spec.(*ast.TypeSpec)
-		if !ok {
-			return ""
-		}
-		// return the first type name found
-		typeName = typeSpec.Name.Name
-		break
-	}
-
-	return typeName
+	return ""
 }
 
 // getTypeDeclarationNames extracts all type names from the given declaration.
@@ -253,7 +242,7 @@ func MakeInterface(comment, pkgName, ifaceName, ifaceComment string, methods []s
 // ParseDeclaredTypes inspect given src code to find type declaractions.
 func ParseDeclaredTypes(src []byte) (declaredTypes []declaredType) {
 	fset := token.NewFileSet()
-	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	a, err := parser.ParseFile(fset, "src.go", src, parser.ParseComments)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -276,7 +265,7 @@ func ParseDeclaredTypes(src []byte) (declaredTypes []declaredType) {
 // the embedding relationship between structs
 func ParseEmbeddingGraph(src []byte) map[string][]string {
 	fileSet := token.NewFileSet()
-	file, err := parser.ParseFile(fileSet, "", src, parser.ParseComments)
+	file, err := parser.ParseFile(fileSet, "src.go", src, parser.ParseComments)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -350,7 +339,7 @@ func ParseEmbeddingGraph(src []byte) map[string][]string {
 // fatally stop the execution
 func ParseStruct(src []byte, structName string, copyDocs bool, copyTypeDocs bool, pkgName string, declaredTypes []declaredType, importModule string, withNotExported bool, embeddedStructNamesSet map[string]struct{}, withPromoted bool) (methods []Method, imports []string, typeDoc string) {
 	fset := token.NewFileSet()
-	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	a, err := parser.ParseFile(fset, "src.go", src, parser.ParseComments)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -432,11 +421,12 @@ func ParseStruct(src []byte, structName string, copyDocs bool, copyTypeDocs bool
 	}
 
 	if copyTypeDocs {
-		pkg := &ast.Package{Files: map[string]*ast.File{"": a}}
-		doc := doc.New(pkg, "", doc.AllDecls)
-		for _, t := range doc.Types {
-			if t.Name == structName {
-				typeDoc = strings.TrimSuffix(t.Doc, "\n")
+		pkgDoc, err := doc.NewFromFiles(fset, []*ast.File{a}, "", doc.AllDecls)
+		if err == nil {
+			for _, t := range pkgDoc.Types {
+				if t.Name == structName {
+					typeDoc = strings.TrimSuffix(t.Doc, "\n")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- close output file after writing
- fix duplicate struct tag for doc option
- fix type name parsing logic
- support doc.NewFromFiles and use valid filenames

## Testing
- `go test ./...`
- `staticcheck ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d482a6ba88333aaa993da1e0671ed