### PR TITLE
Fix struct type validation

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -454,7 +454,7 @@ type MakeOptions struct {
 // types and returns true when present
 func validateStructType(types []declaredType, stType string) bool {
 	for _, v := range types {
-		if strings.EqualFold(v.Name, stType) {
+		if v.Name == stType {
 			return true
 		}
 

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -416,6 +416,14 @@ func Test_validate_struct_types(t *testing.T) {
 			inpSet: func() {},
 			stType: fmt.Sprintf("%s-1", t.Name()),
 		},
+		{
+			name: "case mismatch",
+			inpSet: func() {
+				types = append(types, declaredType{Name: "MyStruct", Package: "pkg"})
+			},
+			stType: "mystruct",
+			exp:    false,
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
## Summary
- treat struct type matches as case sensitive
- test for case mismatch scenario