### PR TITLE
Fix nested slice type handling

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -163,7 +163,7 @@ func getEmbeddedStructName(expr ast.Expr) string {
 // generic types without any modifiers are also matched correctly. The first
 // capture group contains the prefix, if any, and the second group contains the
 // base type name.
-var reMatchTypename = regexp.MustCompile(`^((\[\]|\*|map\[[^\]]+\])*)?(\w+)(\[.+\])?$`)
+var reMatchTypename = regexp.MustCompile(`^(\[\]|\*|\[\]\*|map\[[^\]]+\]|map\[[^\]]+\]\*)?(\w+)(\[.+\])?$`)
 
 // baseIdentName returns the base identifier name from a type expression. It
 // recursively follows pointer, slice, map and generic expressions until the

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -163,7 +163,7 @@ func getEmbeddedStructName(expr ast.Expr) string {
 // generic types without any modifiers are also matched correctly. The first
 // capture group contains the prefix, if any, and the second group contains the
 // base type name.
-var reMatchTypename = regexp.MustCompile(`^(\[\]|\*|\[\]\*|map\[[^\]]+\]|map\[[^\]]+\]\*)?(\w+)(\[.+\])?$`)
+var reMatchTypename = regexp.MustCompile(`^((\[\]|\*|map\[[^\]]+\])*)?(\w+)(\[.+\])?$`)
 
 // baseIdentName returns the base identifier name from a type expression. It
 // recursively follows pointer, slice, map and generic expressions until the

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -185,6 +185,8 @@ func baseIdentName(expr ast.Expr) string {
 		return baseIdentName(e.X)
 	case *ast.IndexListExpr:
 		return baseIdentName(e.X)
+	case *ast.Ellipsis:
+		return baseIdentName(e.Elt)
 	default:
 		return ""
 	}

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -845,6 +845,32 @@ func (f *Foo) Use(x []bar.Type) {}`)
 	require.Equal(t, "x []Type", params[0])
 }
 
+// TestFormatFieldList_MultiDimSlice ensures nested slice modifiers are handled
+// when replacing types from a different package.
+func TestFormatFieldList_MultiDimSlice(t *testing.T) {
+	src := []byte(`package main
+type MyType struct{}
+type Foo struct{}
+func (f *Foo) Bar(x [][]MyType) {}`)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	var fd *ast.FuncDecl
+	for _, d := range file.Decls {
+		if f, ok := d.(*ast.FuncDecl); ok && f.Name.Name == "Bar" {
+			fd = f
+			break
+		}
+	}
+	require.NotNil(t, fd)
+
+	declaredTypes := []declaredType{{Name: "MyType", Package: "other"}}
+	params := FormatFieldList(src, fd.Type.Params, "main", declaredTypes)
+	require.Len(t, params, 1)
+	require.Equal(t, "x [][]other.MyType", params[0])
+}
+
 // TestMake_StructTypeNotFound_EmptyFile covers the branch in Make()
 // where the declared struct type is not found in the input files.
 func TestMake_StructTypeNotFound_EmptyFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- correct type replacement for complex slice expressions
- add regression test for multi-dimensional slices
- document `baseIdentName` helper