### PR TITLE
Fix channel type handling

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -187,6 +187,10 @@ func baseIdentName(expr ast.Expr) string {
 		return baseIdentName(e.X)
 	case *ast.Ellipsis:
 		return baseIdentName(e.Elt)
+	case *ast.ChanType:
+		return baseIdentName(e.Value)
+	case *ast.ParenExpr:
+		return baseIdentName(e.X)
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary
- handle `ast.ChanType` in `baseIdentName`
- add regression test for channel parameters
- support `ast.ParenExpr` in `baseIdentName`
- test for parenthesized parameter types